### PR TITLE
update to Net6 and mzlib 528

### DIFF
--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>1.0.0.0</Version>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="4.9.0" />
-    <PackageReference Include="mzLib" Version="1.0.510" />
+    <PackageReference Include="mzLib" Version="1.0.528" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ## Base image is the Alpine Linux distro with .NET Core runtime
-FROM mcr.microsoft.com/dotnet/runtime:5.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/runtime:6.0-alpine AS build
 
 ## Copies contents of the "publish" folder into the Docker image
-ADD CMD/bin/Release/net5.0/publish/ /flashlfq/
+ADD CMD/bin/Release/net6.0/publish/ /flashlfq/
 
 ## Set the entrypoint of the Docker image to CMD.dll
 ENTRYPOINT ["dotnet", "/flashlfq/CMD.dll"]

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Version>1.0.0.0</Version>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="4.9.0" />
-    <PackageReference Include="mzLib" Version="1.0.510" />
+    <PackageReference Include="mzLib" Version="1.0.528" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="4.9.0" />
-    <PackageReference Include="mzLib" Version="1.0.510" />
+    <PackageReference Include="mzLib" Version="1.0.528" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />

--- a/Util/Util.csproj
+++ b/Util/Util.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>1.0.0.0</Version>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="4.9.0" />
-    <PackageReference Include="mzLib" Version="1.0.510" />
+    <PackageReference Include="mzLib" Version="1.0.528" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>


### PR DESCRIPTION
AC recently updated mzLib to .Net 6.0.  .Net 5.0 will no longer be supported. this pull request updates flashlfq to target .net 6.0 and also gets it updated with the current mzlib release 528