### PR TITLE
Skip empty mzml scans no error reporting

### DIFF
--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>1.0.0.0</Version>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="4.9.0" />
-    <PackageReference Include="mzLib" Version="1.0.510" />
+    <PackageReference Include="mzLib" Version="1.0.528" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="4.9.0" />
-    <PackageReference Include="mzLib" Version="1.0.528" />
+    <PackageReference Include="mzLib" Version="1.0.529" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ## Base image is the Alpine Linux distro with .NET Core runtime
-FROM mcr.microsoft.com/dotnet/runtime:5.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/runtime:6.0-alpine AS build
 
 ## Copies contents of the "publish" folder into the Docker image
-ADD CMD/bin/Release/net5.0/publish/ /flashlfq/
+ADD CMD/bin/Release/net6.0/publish/ /flashlfq/
 
 ## Set the entrypoint of the Docker image to CMD.dll
 ENTRYPOINT ["dotnet", "/flashlfq/CMD.dll"]

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Version>1.0.0.0</Version>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="4.9.0" />
-    <PackageReference Include="mzLib" Version="1.0.510" />
+    <PackageReference Include="mzLib" Version="1.0.528" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="4.9.0" />
-    <PackageReference Include="mzLib" Version="1.0.528" />
+    <PackageReference Include="mzLib" Version="1.0.529" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -212,8 +212,6 @@ namespace Test
             Assert.That(File.Exists(pathOfIdentificationFile));
             Assert.That(File.Exists(pathOfMzml));
 
-
-
             SpectraFileInfo sfi = new SpectraFileInfo(pathOfMzml, "A", 1, 1, 1);
 
             List<double> expectedRetentionTimes = new List<double> { 7.54, 7.54, 7.56, 7.58, 7.61, 7.63 };

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -220,6 +220,14 @@ namespace Test
 
             List<Identification> ids = PsmReader.ReadPsms(pathOfIdentificationFile, true, new List<SpectraFileInfo> { sfi });
             Assert.AreEqual(6, ids.Count);
+
+            //strings separated by commas should be taken literally as protein names
+            Assert.AreEqual(11,ids[0].ProteinGroups.Count);
+            List<string> expectedProteinNameStrings = new() { "sp|Q13885|TBB2A_HUMAN", "tr|M0R1I1|M0R1I1_HUMAN", "tr|Q5JP53|Q5JP53_HUMAN", 
+                "tr|M0QZL7|M0QZL7_HUMAN", "sp|P04350|TBB4A_HUMAN", "sp|P07437|TBB5_HUMAN", "sp|Q9BVA1|TBB2B_HUMAN", "tr|M0R278|M0R278_HUMAN", 
+                "tr|Q5ST81|Q5ST81_HUMAN", "sp|P68371|TBB4B_HUMAN", "tr|M0QY85|M0QY85_HUMAN" };
+            CollectionAssert.AreEquivalent(ids[0].ProteinGroups.Select(n=>n.ProteinGroupName).ToList(), expectedProteinNameStrings);  
+
             List<double> actualRetentionTimes = ids.Select(t => Math.Round(t.Ms2RetentionTimeInMinutes, 2)).ToList();
 
             foreach (double rt in actualRetentionTimes)

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -16,8 +16,8 @@
     <PackageReference Include="MathNet.Numerics" Version="4.9.0" />
     <PackageReference Include="mzLib" Version="1.0.528" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="nunit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
   </ItemGroup>
 

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="4.9.0" />
-    <PackageReference Include="mzLib" Version="1.0.528" />
+    <PackageReference Include="mzLib" Version="1.0.529" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="4.9.0" />
-    <PackageReference Include="mzLib" Version="1.0.510" />
+    <PackageReference Include="mzLib" Version="1.0.528" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />

--- a/Util/PsmReader.cs
+++ b/Util/PsmReader.cs
@@ -40,7 +40,7 @@ namespace Util
             { PsmFileType.MetaMorpheus, new string[] { "|", " or " } },
             { PsmFileType.Morpheus, new string[] { ";" } },
             { PsmFileType.MaxQuant, new string[] { ";" } },
-            { PsmFileType.Percolator, new string[] { "|", "," } },
+            { PsmFileType.Percolator, new string[] { "," } },
             { PsmFileType.Generic, new string[] { ";" } },
             { PsmFileType.PeptideShaker, new string[] { ", " } },
         };
@@ -289,26 +289,23 @@ namespace Util
                         if (fileType == PsmFileType.Percolator)
                         {
                             string[] proteinFastaHeaders = param[_protNameCol].Split(',');
-                            foreach (string fastHeader in proteinFastaHeaders)
+                            foreach (string proteinNameString in proteinFastaHeaders)
                             {
-                                string[] fastaHeaderFields = fastHeader.Split('|');
-                                string accession = fastaHeaderFields[1];
-                                string geneNameString = fastaHeaderFields[2];
 
-                                if (allProteinGroups.TryGetValue(accession, out ProteinGroup pg))
+                                if (allProteinGroups.TryGetValue(proteinNameString, out ProteinGroup pg))
                                 {
                                     proteinGroups.Add(pg);
                                 }
                                 else
                                 {
-                                    ProteinGroup newPg = new ProteinGroup(accession, geneNameString, null);
-                                    allProteinGroups.Add(accession, newPg);
+                                    ProteinGroup newPg = new ProteinGroup(proteinNameString, null, null);
+                                    allProteinGroups.Add(proteinNameString, newPg);
                                     proteinGroups.Add(newPg);
                                 }
 
                             }
                         }
-                        else
+                        else // non-percolator protein column
                         {
                             proteins = param[_protNameCol].Split(delimiters[fileType], StringSplitOptions.None);
 

--- a/Util/Util.csproj
+++ b/Util/Util.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>1.0.0.0</Version>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="4.9.0" />
-    <PackageReference Include="mzLib" Version="1.0.510" />
+    <PackageReference Include="mzLib" Version="1.0.528" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>

--- a/Util/Util.csproj
+++ b/Util/Util.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="4.9.0" />
-    <PackageReference Include="mzLib" Version="1.0.528" />
+    <PackageReference Include="mzLib" Version="1.0.529" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>


### PR DESCRIPTION
Reading mzML files produce a crash when any of the scans has no mz/intensity data. This PR is for an amended version of mzLib that skips those scans during the file read. NOTE: THERE IS NO ERROR REPORTING. I couldn't think of a way to do this that wouldn't break every call to file read. When I find a good solution, I will update mzLib and then flashLFQ.

side note: i also updated the version of NUNIT in this PR for no good reason other than I could