### PR TITLE
Lower number of isotopes required to 1 but leave default at 2

### DIFF
--- a/Util/FlashLfqSettings.cs
+++ b/Util/FlashLfqSettings.cs
@@ -188,9 +188,10 @@ namespace Util
                 throw new Exception("The isotope PPM tolerance must be greater than 0");
             }
 
-            if (NumIsotopesRequired < 2)
+            if (NumIsotopesRequired < 1)
             {
-                throw new Exception("The number of isotopes required must be at least 2");
+                //We leave the default setting to 2. But some applications, such as single-cell analysis, require operation with fewer isotope peaks.
+                throw new Exception("The number of isotopes required must be at least 1");
             }
 
             if (MbrRtWindow <= 0)


### PR DESCRIPTION
Some applications, like single cell proteomics, yield lower quality spectra. This results in several psms identified by the search engine showing up as an MBR peak in FlashLFQ instead of an MSMS identified peak. 