### PR TITLE
mzlib update to fix filename mismatch and failure to load ids

### DIFF
--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.534" />
+    <PackageReference Include="mzLib" Version="1.0.535" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="mzLib" Version="1.0.535" />
-    <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />
     <PackageReference Include="SharpLearning.Containers" Version="0.28.0" />

--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -11,7 +11,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <ApplicationIcon>FlashLFQ_Icon.ico</ApplicationIcon>
-    <Platforms>AnyCPU;x64</Platforms>
+    <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="mzLib" Version="1.0.535" />
+    <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />
     <PackageReference Include="SharpLearning.Containers" Version="0.28.0" />

--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -11,12 +11,13 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <ApplicationIcon>FlashLFQ_Icon.ico</ApplicationIcon>
+    <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
-    <PackageReference Include="MathNet.Numerics" Version="4.9.0" />
-    <PackageReference Include="mzLib" Version="1.0.529" />
+    <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
+    <PackageReference Include="mzLib" Version="1.0.534" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/CMD/FlashLFQExecutable.cs
+++ b/CMD/FlashLFQExecutable.cs
@@ -2,9 +2,9 @@
 using CommandLine.Text;
 using FlashLFQ;
 using IO.ThermoRawFileReader;
+using MzLibUtil;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Util;
@@ -69,11 +69,11 @@ namespace CMD
                 .Where(f => acceptedSpectrumFileFormats.Contains(Path.GetExtension(f).ToLowerInvariant())).ToList();
 
             // check for duplicate file names (agnostic of file extension)
-            foreach (var fileNameWithoutExtension in filePaths.GroupBy(p => Path.GetFileNameWithoutExtension(p)))
+            foreach (var fileNameWithoutExtension in filePaths.GroupBy(p => PeriodTolerantFilenameWithoutExtension.GetPeriodTolerantFilenameWithoutExtension(p)))
             {
                 if (fileNameWithoutExtension.Count() > 1)
                 {
-                    var types = fileNameWithoutExtension.Select(p => Path.GetFileNameWithoutExtension(p)).Distinct();
+                    var types = fileNameWithoutExtension.Select(p => PeriodTolerantFilenameWithoutExtension.GetPeriodTolerantFilenameWithoutExtension(p)).Distinct();
 
                     if (!settings.Silent)
                     {
@@ -142,7 +142,7 @@ namespace CMD
 
                 foreach (var file in filePaths)
                 {
-                    string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(file);
+                    string fileNameWithoutExtension = PeriodTolerantFilenameWithoutExtension.GetPeriodTolerantFilenameWithoutExtension(file);
 
                     var expDesignForThisFile = experimentalDesign[fileNameWithoutExtension];
                     var split = expDesignForThisFile.Split('\t');

--- a/CMD/FlashLFQExecutable.cs
+++ b/CMD/FlashLFQExecutable.cs
@@ -140,9 +140,9 @@ namespace CMD
                 var experimentalDesign = File.ReadAllLines(assumedPathToExpDesign)
                     .ToDictionary(v => v.Split('\t')[0], v => v);
 
-                foreach (var file in filePaths)
+                foreach (var filePath in filePaths)
                 {
-                    string fileNameWithoutExtension = PeriodTolerantFilenameWithoutExtension.GetPeriodTolerantFilenameWithoutExtension(file);
+                    string fileNameWithoutExtension = PeriodTolerantFilenameWithoutExtension.GetPeriodTolerantFilenameWithoutExtension(filePath);
 
                     var expDesignForThisFile = experimentalDesign[fileNameWithoutExtension];
                     var split = expDesignForThisFile.Split('\t');
@@ -153,7 +153,7 @@ namespace CMD
                     int techrep = int.Parse(split[4]);
 
                     // experimental design info passed in here for each spectra file
-                    spectraFileInfos.Add(new SpectraFileInfo(fullFilePathWithExtension: file,
+                    spectraFileInfos.Add(new SpectraFileInfo(fullFilePathWithExtension: filePath,
                         condition: condition,
                         biorep: biorep - 1,
                         fraction: fraction - 1,

--- a/FlashLFQ.sln
+++ b/FlashLFQ.sln
@@ -1,38 +1,56 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29418.71
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32825.248
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GUI", "GUI\GUI.csproj", "{976C4F84-5EF1-4549-BC2C-4F5E946D36E9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GUI", "GUI\GUI.csproj", "{976C4F84-5EF1-4549-BC2C-4F5E946D36E9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CMD", "CMD\CMD.csproj", "{6020A640-2854-41EC-BC90-73D6A0C1F74D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CMD", "CMD\CMD.csproj", "{6020A640-2854-41EC-BC90-73D6A0C1F74D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test", "Test\Test.csproj", "{E59D0D0F-EEC9-48AA-8DBF-F488CF0B5FA4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test", "Test\Test.csproj", "{E59D0D0F-EEC9-48AA-8DBF-F488CF0B5FA4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Util", "Util\Util.csproj", "{2C3A8087-6AFB-4EED-BF7E-93E872C699A5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Util", "Util\Util.csproj", "{2C3A8087-6AFB-4EED-BF7E-93E872C699A5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{976C4F84-5EF1-4549-BC2C-4F5E946D36E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{976C4F84-5EF1-4549-BC2C-4F5E946D36E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{976C4F84-5EF1-4549-BC2C-4F5E946D36E9}.Debug|x64.ActiveCfg = Debug|x64
+		{976C4F84-5EF1-4549-BC2C-4F5E946D36E9}.Debug|x64.Build.0 = Debug|x64
 		{976C4F84-5EF1-4549-BC2C-4F5E946D36E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{976C4F84-5EF1-4549-BC2C-4F5E946D36E9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{976C4F84-5EF1-4549-BC2C-4F5E946D36E9}.Release|x64.ActiveCfg = Release|x64
+		{976C4F84-5EF1-4549-BC2C-4F5E946D36E9}.Release|x64.Build.0 = Release|x64
 		{6020A640-2854-41EC-BC90-73D6A0C1F74D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6020A640-2854-41EC-BC90-73D6A0C1F74D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6020A640-2854-41EC-BC90-73D6A0C1F74D}.Debug|x64.ActiveCfg = Debug|x64
+		{6020A640-2854-41EC-BC90-73D6A0C1F74D}.Debug|x64.Build.0 = Debug|x64
 		{6020A640-2854-41EC-BC90-73D6A0C1F74D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6020A640-2854-41EC-BC90-73D6A0C1F74D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6020A640-2854-41EC-BC90-73D6A0C1F74D}.Release|x64.ActiveCfg = Release|x64
+		{6020A640-2854-41EC-BC90-73D6A0C1F74D}.Release|x64.Build.0 = Release|x64
 		{E59D0D0F-EEC9-48AA-8DBF-F488CF0B5FA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E59D0D0F-EEC9-48AA-8DBF-F488CF0B5FA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E59D0D0F-EEC9-48AA-8DBF-F488CF0B5FA4}.Debug|x64.ActiveCfg = Debug|x64
+		{E59D0D0F-EEC9-48AA-8DBF-F488CF0B5FA4}.Debug|x64.Build.0 = Debug|x64
 		{E59D0D0F-EEC9-48AA-8DBF-F488CF0B5FA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E59D0D0F-EEC9-48AA-8DBF-F488CF0B5FA4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E59D0D0F-EEC9-48AA-8DBF-F488CF0B5FA4}.Release|x64.ActiveCfg = Release|x64
+		{E59D0D0F-EEC9-48AA-8DBF-F488CF0B5FA4}.Release|x64.Build.0 = Release|x64
 		{2C3A8087-6AFB-4EED-BF7E-93E872C699A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2C3A8087-6AFB-4EED-BF7E-93E872C699A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C3A8087-6AFB-4EED-BF7E-93E872C699A5}.Debug|x64.ActiveCfg = Debug|x64
+		{2C3A8087-6AFB-4EED-BF7E-93E872C699A5}.Debug|x64.Build.0 = Debug|x64
 		{2C3A8087-6AFB-4EED-BF7E-93E872C699A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2C3A8087-6AFB-4EED-BF7E-93E872C699A5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C3A8087-6AFB-4EED-BF7E-93E872C699A5}.Release|x64.ActiveCfg = Release|x64
+		{2C3A8087-6AFB-4EED-BF7E-93E872C699A5}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/FlashLFQ.sln
+++ b/FlashLFQ.sln
@@ -14,43 +14,25 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
-		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{976C4F84-5EF1-4549-BC2C-4F5E946D36E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{976C4F84-5EF1-4549-BC2C-4F5E946D36E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{976C4F84-5EF1-4549-BC2C-4F5E946D36E9}.Debug|x64.ActiveCfg = Debug|x64
-		{976C4F84-5EF1-4549-BC2C-4F5E946D36E9}.Debug|x64.Build.0 = Debug|x64
 		{976C4F84-5EF1-4549-BC2C-4F5E946D36E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{976C4F84-5EF1-4549-BC2C-4F5E946D36E9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{976C4F84-5EF1-4549-BC2C-4F5E946D36E9}.Release|x64.ActiveCfg = Release|x64
-		{976C4F84-5EF1-4549-BC2C-4F5E946D36E9}.Release|x64.Build.0 = Release|x64
 		{6020A640-2854-41EC-BC90-73D6A0C1F74D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6020A640-2854-41EC-BC90-73D6A0C1F74D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6020A640-2854-41EC-BC90-73D6A0C1F74D}.Debug|x64.ActiveCfg = Debug|x64
-		{6020A640-2854-41EC-BC90-73D6A0C1F74D}.Debug|x64.Build.0 = Debug|x64
 		{6020A640-2854-41EC-BC90-73D6A0C1F74D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6020A640-2854-41EC-BC90-73D6A0C1F74D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6020A640-2854-41EC-BC90-73D6A0C1F74D}.Release|x64.ActiveCfg = Release|x64
-		{6020A640-2854-41EC-BC90-73D6A0C1F74D}.Release|x64.Build.0 = Release|x64
 		{E59D0D0F-EEC9-48AA-8DBF-F488CF0B5FA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E59D0D0F-EEC9-48AA-8DBF-F488CF0B5FA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E59D0D0F-EEC9-48AA-8DBF-F488CF0B5FA4}.Debug|x64.ActiveCfg = Debug|x64
-		{E59D0D0F-EEC9-48AA-8DBF-F488CF0B5FA4}.Debug|x64.Build.0 = Debug|x64
 		{E59D0D0F-EEC9-48AA-8DBF-F488CF0B5FA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E59D0D0F-EEC9-48AA-8DBF-F488CF0B5FA4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E59D0D0F-EEC9-48AA-8DBF-F488CF0B5FA4}.Release|x64.ActiveCfg = Release|x64
-		{E59D0D0F-EEC9-48AA-8DBF-F488CF0B5FA4}.Release|x64.Build.0 = Release|x64
 		{2C3A8087-6AFB-4EED-BF7E-93E872C699A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2C3A8087-6AFB-4EED-BF7E-93E872C699A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2C3A8087-6AFB-4EED-BF7E-93E872C699A5}.Debug|x64.ActiveCfg = Debug|x64
-		{2C3A8087-6AFB-4EED-BF7E-93E872C699A5}.Debug|x64.Build.0 = Debug|x64
 		{2C3A8087-6AFB-4EED-BF7E-93E872C699A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2C3A8087-6AFB-4EED-BF7E-93E872C699A5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2C3A8087-6AFB-4EED-BF7E-93E872C699A5}.Release|x64.ActiveCfg = Release|x64
-		{2C3A8087-6AFB-4EED-BF7E-93E872C699A5}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -12,11 +12,12 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <ApplicationIcon>FlashLFQ_Icon.ico</ApplicationIcon>
+    <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MathNet.Numerics" Version="4.9.0" />
-    <PackageReference Include="mzLib" Version="1.0.529" />
+    <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
+    <PackageReference Include="mzLib" Version="1.0.534" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="mzLib" Version="1.0.535" />
+    <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />
     <PackageReference Include="SharpLearning.Containers" Version="0.28.0" />

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -18,7 +18,6 @@
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="mzLib" Version="1.0.535" />
-    <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />
     <PackageReference Include="SharpLearning.Containers" Version="0.28.0" />

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -12,7 +12,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <ApplicationIcon>FlashLFQ_Icon.ico</ApplicationIcon>
-    <Platforms>AnyCPU;x64</Platforms>
+    <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.534" />
+    <PackageReference Include="mzLib" Version="1.0.535" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -184,7 +184,7 @@ namespace Test
                 "5"
             };
 
-            CMD.FlashLfqExecutable.Main(myargs);
+            FlashLfqExecutable.Main(myargs);
 
             string peaksPath = Path.Combine(myDirectory, "QuantifiedPeaks.tsv");
             Assert.That(File.Exists(peaksPath));

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -214,7 +214,7 @@ namespace Test
 
             SpectraFileInfo sfi = new SpectraFileInfo(pathOfMzml, "A", 1, 1, 1);
 
-            List<double> expectedRetentionTimes = new List<double> { 7.54, 7.54, 7.56, 7.58, 7.61, 7.63 };
+            List<double> expectedRetentionTimes = new() { 7.54, 7.54, 7.56, 7.58, 7.61, 7.63 };
 
             List<Identification> ids = PsmReader.ReadPsms(pathOfIdentificationFile, true, new List<SpectraFileInfo> { sfi });
             Assert.AreEqual(6, ids.Count);
@@ -234,7 +234,7 @@ namespace Test
             }
             CollectionAssert.AreEquivalent(expectedRetentionTimes, actualRetentionTimes);
 
-            List<int> proteinGroupCounts = new List<int> { 11, 6, 3, 2, 15, 3 };
+            List<int> proteinGroupCounts = new() { 11, 6, 3, 2, 15, 3 };
             CollectionAssert.AreEquivalent(proteinGroupCounts, ids.Select(i => i.ProteinGroups.Count).ToList());
         }
 

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -16,7 +16,6 @@
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="mzLib" Version="1.0.535" />
-    <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Platforms>AnyCPU;x64</Platforms>
+    <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -10,11 +10,12 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MathNet.Numerics" Version="4.9.0" />
-    <PackageReference Include="mzLib" Version="1.0.529" />
+    <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
+    <PackageReference Include="mzLib" Version="1.0.534" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.534" />
+    <PackageReference Include="mzLib" Version="1.0.535" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="mzLib" Version="1.0.535" />
+    <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />

--- a/Util/OutputWriter.cs
+++ b/Util/OutputWriter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using FlashLFQ;
@@ -16,7 +15,7 @@ namespace Util
                 outputPath = Path.GetDirectoryName(inputPath);
             }
 
-            string inputFileName = Path.GetFileNameWithoutExtension(inputPath);
+            string inputFileName = PeriodTolerantFilenameWithoutExtension.GetPeriodTolerantFilenameWithoutExtension(inputPath);
 
             if (!Directory.Exists(outputPath))
             {
@@ -41,7 +40,7 @@ namespace Util
                 outputPath = Path.GetDirectoryName(inputPath);
             }
 
-            string inputFileName = Path.GetFileNameWithoutExtension(inputPath);
+            string inputFileName = PeriodTolerantFilenameWithoutExtension.GetPeriodTolerantFilenameWithoutExtension(inputPath);
 
             if (!Directory.Exists(outputPath))
             {

--- a/Util/PsmReader.cs
+++ b/Util/PsmReader.cs
@@ -94,9 +94,8 @@ namespace Util
             {
                 throw new Exception("Could not interpret PSM header labels from file: " + filepath);
             }
-            var j = Path.GetFileNameWithoutExtension();
-            var j = MzLibUtil. PeriodTolerantFilenameWithoutExtension.GetPeriodTolerantFilenameWithoutExtension();
-            var psmsGroupedByFile = inputPsms.GroupBy(p => Path.GetFileNameWithoutExtension(p.Split('\t')[_fileNameCol])).ToList();
+
+            var psmsGroupedByFile = inputPsms.GroupBy(p => PeriodTolerantFilenameWithoutExtension.GetPeriodTolerantFilenameWithoutExtension(p.Split('\t')[_fileNameCol])).ToList();
 
             foreach (var fileSpecificPsms in psmsGroupedByFile)
             {
@@ -189,7 +188,7 @@ namespace Util
             }
 
             // spectrum file name
-            string fileName = Path.GetFileNameWithoutExtension(param[_fileNameCol]);
+            string fileName = PeriodTolerantFilenameWithoutExtension.GetPeriodTolerantFilenameWithoutExtension(param[_fileNameCol]);
 
             // base sequence
             string baseSequence = param[_baseSequCol];
@@ -447,7 +446,7 @@ namespace Util
 
             if (int.TryParse(param[_msmsScanCol], NumberStyles.Number, CultureInfo.InvariantCulture, out int scanNumber))
             {
-                ms2RetentionTime = scanHeaderInfo.Where(i => Path.GetFileNameWithoutExtension(i.FileNameWithoutExtension) == Path.GetFileNameWithoutExtension(fileName) && i.ScanNumber == scanNumber).FirstOrDefault().RetentionTime;
+                ms2RetentionTime = scanHeaderInfo.Where(i => PeriodTolerantFilenameWithoutExtension.GetPeriodTolerantFilenameWithoutExtension(i.FileNameWithoutExtension) == PeriodTolerantFilenameWithoutExtension.GetPeriodTolerantFilenameWithoutExtension(fileName) && i.ScanNumber == scanNumber).FirstOrDefault().RetentionTime;
             }
 
             // charge state
@@ -534,7 +533,7 @@ namespace Util
                 }
             }
 
-            if (!rawFileDictionary.TryGetValue(Path.GetFileNameWithoutExtension(fileName), out SpectraFileInfo spectraFileInfoToUse))
+            if (!rawFileDictionary.TryGetValue(PeriodTolerantFilenameWithoutExtension.GetPeriodTolerantFilenameWithoutExtension(fileName), out SpectraFileInfo spectraFileInfoToUse))
             {
                 // skip PSMs for files with no spectrum data input
                 return null;

--- a/Util/PsmReader.cs
+++ b/Util/PsmReader.cs
@@ -1,4 +1,5 @@
 ﻿using FlashLFQ;
+using MzLibUtil;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -93,7 +94,8 @@ namespace Util
             {
                 throw new Exception("Could not interpret PSM header labels from file: " + filepath);
             }
-
+            var j = Path.GetFileNameWithoutExtension();
+            var j = MzLibUtil. PeriodTolerantFilenameWithoutExtension.GetPeriodTolerantFilenameWithoutExtension();
             var psmsGroupedByFile = inputPsms.GroupBy(p => Path.GetFileNameWithoutExtension(p.Split('\t')[_fileNameCol])).ToList();
 
             foreach (var fileSpecificPsms in psmsGroupedByFile)

--- a/Util/PsmReader.cs
+++ b/Util/PsmReader.cs
@@ -532,7 +532,7 @@ namespace Util
                 }
             }
 
-            if (!rawFileDictionary.TryGetValue(fileName, out SpectraFileInfo spectraFileInfoToUse))
+            if (!rawFileDictionary.TryGetValue(Path.GetFileNameWithoutExtension(fileName), out SpectraFileInfo spectraFileInfoToUse))
             {
                 // skip PSMs for files with no spectrum data input
                 return null;

--- a/Util/ScanInfoRecovery.cs
+++ b/Util/ScanInfoRecovery.cs
@@ -16,7 +16,7 @@ namespace Util
 
         public static List<ScanHeaderInfo> FileScanHeaderInfo(string fullFilePathWithExtension)
         {
-            string filename = Path.GetFileNameWithoutExtension(fullFilePathWithExtension);
+            string filename = PeriodTolerantFilenameWithoutExtension.GetPeriodTolerantFilenameWithoutExtension(fullFilePathWithExtension);
             List<ScanHeaderInfo> scanHeaderInfoList = new();
             switch (GetDataFileType(fullFilePathWithExtension))
             {

--- a/Util/Util.csproj
+++ b/Util/Util.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="mzLib" Version="1.0.535" />
-    <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>
 

--- a/Util/Util.csproj
+++ b/Util/Util.csproj
@@ -9,12 +9,13 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
-    <PackageReference Include="MathNet.Numerics" Version="4.9.0" />
-    <PackageReference Include="mzLib" Version="1.0.529" />
+    <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
+    <PackageReference Include="mzLib" Version="1.0.534" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>

--- a/Util/Util.csproj
+++ b/Util/Util.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="mzLib" Version="1.0.535" />
+    <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>
 

--- a/Util/Util.csproj
+++ b/Util/Util.csproj
@@ -9,7 +9,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Platforms>AnyCPU;x64</Platforms>
+    <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Util/Util.csproj
+++ b/Util/Util.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.534" />
+    <PackageReference Include="mzLib" Version="1.0.535" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>


### PR DESCRIPTION
But fixed in file reading where filename from PSMTSV did not match the dictionary.

I validated function both in GUI and CMD using Noble percolator.target.psms.txt file and the Pf_C1-593_MixES-Sol_SG-1_rKCTi_VO2_108.mzML

New method in mzlib to return filename without extension. This method allows extraneous periods in the file path.

Some nuget package updates.