### PR TITLE
update to mzlib 539

### DIFF
--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.535" />
+    <PackageReference Include="mzLib" Version="5.0.539" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.535" />
+    <PackageReference Include="mzLib" Version="5.0.539" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.535" />
+    <PackageReference Include="mzLib" Version="5.0.539" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/Util/ScanInfoRecovery.cs
+++ b/Util/ScanInfoRecovery.cs
@@ -21,7 +21,7 @@ namespace Util
             switch (GetDataFileType(fullFilePathWithExtension))
             {
                 case DataFileType.Thermo:
-                    ThermoRawFileReader staticRaw = ThermoRawFileReader.LoadAllStaticData(fullFilePathWithExtension);
+                    MsDataFile staticRaw = ThermoRawFileReader.LoadAllStaticData(fullFilePathWithExtension);
                     foreach (MsDataScan item in staticRaw)
                     {
                         scanHeaderInfoList.Add(new ScanHeaderInfo(fullFilePathWithExtension, filename, item.OneBasedScanNumber, item.RetentionTime));

--- a/Util/Util.csproj
+++ b/Util/Util.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.535" />
+    <PackageReference Include="mzLib" Version="5.0.539" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>


### PR DESCRIPTION
These are the release notes from MzLib 539:

Reader Refactor

mzLib 1.0.539 is not backwards compatible. The IO.MzmlMethods class has been moved to Readers.MzmlMethods, but all functionality has been maintained. Updating to mzLib 1.0.539 will require using directives to be changed to reflect the new namespace.

MsDataFile is now an abstract type defining methods to read data from files, both statically and dynamically.
Previously supported data types (.raw, .mzml. .mgf) are still supported with previous syntax, but can also now be constructed with the unified syntax below:

MsDataFile file = MsDataFileReader.ReadDataFile("msFilePath.raw");
MsDataFile file = MsDataFileReader.ReadDataFile("msFilePath.mzML");
MsDataFile file = MsDataFileReader.ReadDataFile("msFilePath.mgf");

To receive the data from the MsDataFile object, the following methods are available:

    GetMsDataScans() -> an array of all scans
    GetAllScansList() -> a list of all scans
    GetMs1Scans() -> a list of all Ms1 scans
    GetOneBasedScan(int scanNumber) -> get a scan from the file based upon its scan number
    GetMsScansInTimeRange(startTime, endTime) -> gets all scans within retention time range
    GetClosestOneBasedScanNumber(retentionTime) -> gets scan number of scan closest to retentionTime

To receive data dynamically (without loading the whole file), each MsdataFile class has the following methods available:

    InitiateDynamicConnection() -> initiates the dynamic connection
    GetOneBasedScanFromDynamicConnection(scanNumber) -> gets a single scan from the dynamic connection based upon its scan number
    CloseDynamicConnection() -> disposes of the dynamic connection

To add a new supported data type:

    Create a new class for the data type, inherit from MsDataScan, and implement all of the required methods.
    Add a case to the switch method in the MsDataFileReader class for the new data type

Other Changes

    There was a bug wherein adding two chemical formulas with negative isotopes gave the wrong answer. The example was deamidation (H-1N-1O) plus deamidation. The expected answer is H-2N-2O2 but the original gave O2. Added by @trishorts in https://github.com/smith-chem-wisc/mzLib/pull/697
    Deconvolution Testing Environment was added by @nbollis in https://github.com/smith-chem-wisc/mzLib/pull/690. This environment is not included in release versions of mzLib
    Added option to quantify ambiguous peptides in FlashLFQ by @Alexander-Sol in https://github.com/smith-chem-wisc/mzLib/pull/700
    Averaging Updates by @nbollis in https://github.com/smith-chem-wisc/mzLib/pull/683

Full Changelog: https://github.com/smith-chem-wisc/mzLib/compare/1.0.538...1.0.539