### PR TITLE
Update to mz lib541

### DIFF
--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="5.0.539" />
+    <PackageReference Include="mzLib" Version="1.0.541" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.535" />
+    <PackageReference Include="mzLib" Version="5.0.539" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.535" />
+    <PackageReference Include="mzLib" Version="5.0.539" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="5.0.539" />
+    <PackageReference Include="mzLib" Version="1.0.541" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.535" />
+    <PackageReference Include="mzLib" Version="5.0.539" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="5.0.539" />
+    <PackageReference Include="mzLib" Version="1.0.541" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/Util/ScanInfoRecovery.cs
+++ b/Util/ScanInfoRecovery.cs
@@ -21,7 +21,7 @@ namespace Util
             switch (GetDataFileType(fullFilePathWithExtension))
             {
                 case DataFileType.Thermo:
-                    ThermoRawFileReader staticRaw = ThermoRawFileReader.LoadAllStaticData(fullFilePathWithExtension);
+                    MsDataFile staticRaw = ThermoRawFileReader.LoadAllStaticData(fullFilePathWithExtension);
                     foreach (MsDataScan item in staticRaw)
                     {
                         scanHeaderInfoList.Add(new ScanHeaderInfo(fullFilePathWithExtension, filename, item.OneBasedScanNumber, item.RetentionTime));

--- a/Util/Util.csproj
+++ b/Util/Util.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="5.0.539" />
+    <PackageReference Include="mzLib" Version="1.0.541" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>

--- a/Util/Util.csproj
+++ b/Util/Util.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.535" />
+    <PackageReference Include="mzLib" Version="5.0.539" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>


### PR DESCRIPTION
mzlib 541 release notes:
Added support for Bruker data https://github.com/smith-chem-wisc/mzLib/pull/702
Fixed chemical formula bug
Update to uniprot ptmlist.txt loader
Fixed xml.gz compression bug so we load complete xml
Improved comments in FlashLFQ
Added support for FlashDecon and TopFD file parsing
New method to check valid amino acid sequence to help with reading data from outside programs
Improved ability of FlashLFQ to handle unusual characters in file input
Added support for negative deconvolution

I ran the vignette data with the existing release and with this PR. Then I plotted to log2 protein intensity ratios against one another. We do get a slightly increased number of protein intensities as expected.
![image](https://github.com/smith-chem-wisc/FlashLFQ/assets/16841846/5c4ea4a7-8270-4cca-9dbe-65eb417271e4)
