### PR TITLE
.NET 8 Update

### DIFF
--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.544" />
+    <PackageReference Include="mzLib" Version="1.0.552" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.552" />
+    <PackageReference Include="mzLib" Version="7.7.7" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="7.7.7" />
+    <PackageReference Include="mzLib" Version="1.0.552" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.543" />
+    <PackageReference Include="mzLib" Version="1.0.544" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>1.0.0.0</Version>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -13,7 +12,6 @@
     <ApplicationIcon>FlashLFQ_Icon.ico</ApplicationIcon>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
@@ -30,11 +28,9 @@
     <PackageReference Include="SharpLearning.Optimization" Version="0.28.0" />
     <PackageReference Include="SharpLearning.RandomForest" Version="0.28.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Util\Util.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="FlashLFQ_Icon.ico">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -43,5 +39,4 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## Base image is the Alpine Linux distro with .NET Core runtime
-FROM mcr.microsoft.com/dotnet/runtime:6.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/runtime:8.0-alpine AS build
 
 ## Copies contents of the "publish" folder into the Docker image
 ADD CMD/bin/Release/net8.0/publish/ /flashlfq/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM mcr.microsoft.com/dotnet/runtime:6.0-alpine AS build
 
 ## Copies contents of the "publish" folder into the Docker image
-ADD CMD/bin/Release/net6.0/publish/ /flashlfq/
+ADD CMD/bin/Release/net8.0/publish/ /flashlfq/
 
 ## Set the entrypoint of the Docker image to CMD.dll
 ENTRYPOINT ["dotnet", "/flashlfq/CMD.dll"]

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Version>1.0.0.0</Version>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
@@ -14,7 +13,6 @@
     <ApplicationIcon>FlashLFQ_Icon.ico</ApplicationIcon>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="mzLib" Version="1.0.544" />
@@ -30,15 +28,12 @@
     <PackageReference Include="SharpLearning.Optimization" Version="0.28.0" />
     <PackageReference Include="SharpLearning.RandomForest" Version="0.28.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Util\Util.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="FlashLFQ_Icon.ico">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.543" />
+    <PackageReference Include="mzLib" Version="1.0.544" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="7.7.7" />
+    <PackageReference Include="mzLib" Version="1.0.552" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.552" />
+    <PackageReference Include="mzLib" Version="7.7.7" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.544" />
+    <PackageReference Include="mzLib" Version="1.0.552" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/README.md
+++ b/README.md
@@ -18,13 +18,7 @@ This repository is for the stand-alone application of FlashLFQ. FlashLFQ is also
 
 The command-line version of FlashLFQ is cross-platform (Windows, macOS, or Linux). The GUI is Windows-only.
 
-.NET 6 is required for both the command-line and GUI version:
-
-Windows: https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-desktop-6.0.4-windows-x64-installer
-
-Mac: https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-6.0.4-macos-x64-installer
-
-Linux: https://docs.microsoft.com/dotnet/core/install/linux?WT.mc_id=dotnet-35129-website
+.NET 8 is required for both the command-line and GUI version: https://dotnet.microsoft.com/en-us/download/dotnet/8.0
 
 ## Download
 To download FlashLFQ, go [here](https://github.com/smith-chem-wisc/FlashLFQ/releases/latest). Click the FlashLFQ.zip file and extract the contents to a desired location on your computer.

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -3,6 +3,8 @@ using FlashLFQ;
 using IO.MzML;
 using MzLibUtil;
 using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+using CollectionAssert = NUnit.Framework.Legacy.CollectionAssert;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="7.7.7" />
+    <PackageReference Include="mzLib" Version="1.0.552" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="nunit" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.543" />
+    <PackageReference Include="mzLib" Version="1.0.544" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.552" />
+    <PackageReference Include="mzLib" Version="7.7.7" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="nunit" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.544" />
+    <PackageReference Include="mzLib" Version="1.0.552" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="nunit" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="mzLib" Version="1.0.544" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
-    <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="nunit" Version="4.2.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -12,7 +10,6 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="mzLib" Version="1.0.544" />
@@ -21,12 +18,10 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\CMD\CMD.csproj" />
     <ProjectReference Include="..\Util\Util.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="SampleFiles\Parallel\20100614_Velos1_TaGe_SA_Jurkat_3.mzML">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -80,5 +75,4 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/Util/Util.csproj
+++ b/Util/Util.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.543" />
+    <PackageReference Include="mzLib" Version="1.0.544" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>

--- a/Util/Util.csproj
+++ b/Util/Util.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>1.0.0.0</Version>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -11,7 +10,6 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
@@ -19,5 +17,4 @@
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>
-
 </Project>

--- a/Util/Util.csproj
+++ b/Util/Util.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.552" />
+    <PackageReference Include="mzLib" Version="7.7.7" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>

--- a/Util/Util.csproj
+++ b/Util/Util.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.544" />
+    <PackageReference Include="mzLib" Version="1.0.552" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>

--- a/Util/Util.csproj
+++ b/Util/Util.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="7.7.7" />
+    <PackageReference Include="mzLib" Version="1.0.552" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>


### PR DESCRIPTION
Updated FlashLFQ to .NET 8 so that it can use newer versions of mzLib.