### PR TITLE
Remove warning

### DIFF
--- a/CMD/FlashLFQExecutable.cs
+++ b/CMD/FlashLFQExecutable.cs
@@ -203,16 +203,19 @@ namespace CMD
             }
 
             // determine which peptides should be quantified and used as donors for MBR
-            List<string> peptidesToQuantify;
-            try
+            List<string> peptidesToQuantify = null;
+            if (!settings.PeptideIdentificationPath.IsNullOrEmptyOrWhiteSpace())
             {
-                peptidesToQuantify = PsmReader.ReadPsms(settings.PeptideIdentificationPath, settings.Silent, spectraFileInfos, usePepQValue: settings.UsePepQValue)
-                    .Select(id => id.ModifiedSequence).ToList();
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine("Problem reading Peptidess: " + e.Message);
-                return;
+                try
+                {
+                    peptidesToQuantify = PsmReader.ReadPsms(settings.PeptideIdentificationPath, settings.Silent, spectraFileInfos, usePepQValue: settings.UsePepQValue)
+                        .Select(id => id.ModifiedSequence).ToList();
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine("Problem reading Peptides: " + e.Message);
+                    return;
+                }
             }
 
             if (ids.Any())

--- a/Util/FlashLfqSettings.cs
+++ b/Util/FlashLfqSettings.cs
@@ -87,13 +87,15 @@ namespace Util
 
         [Option("rns", HelpText = "int; random seed for the Bayesian protein fold-change analysis")]
         public int? RandomSeed { get; set; }
-        //TODO: paired samples
 
         [Option("pipfdr", HelpText = "double; fdr cutoff for pip")]
-        public double MbrDetectionQValueThreshold  { get; set; }
+        public double MbrDetectionQValueThreshold { get; set; }
 
         [Option("usepepq", Default = false, HelpText = "bool; determines whether PEP Q Value should be used to determine which peptides to quantify")]
         public bool UsePepQValue { get; set; }
+
+        //TODO: paired samples
+
 
         public FlashLfqSettings()
         {


### PR DESCRIPTION
Previously, FlashLFQ issued a warning when a peptide identification file wasn't included. This PR checks if a peptide ID input was given and, if it wasn't, doesn't attempt to parse the file, thereby eliminating the warning.