### PR TITLE
Added support for FlashLFQParameters

### DIFF
--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.553" />
+    <PackageReference Include="mzLib" Version="8.1.2" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.553" />
+    <PackageReference Include="mzLib" Version="8.1.2" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.28.0" />

--- a/GUI/MainWindow.xaml.cs
+++ b/GUI/MainWindow.xaml.cs
@@ -93,7 +93,7 @@ namespace GUI
             precursorIdOnlyCheckbox.IsChecked = settings.IdSpecificChargeState;
             isotopePpmToleranceTextBox.Text = settings.IsotopePpmTolerance.ToString("F1");
             numIsotopesRequiredTextBox.Text = settings.NumIsotopesRequired.ToString();
-            mbrRtWindowTextBox.Text = settings.MbrRtWindow.ToString("F1");
+            mbrRtWindowTextBox.Text = settings.MaxMbrRtWindow.ToString("F1");
             mcmcIterationsTextBox.Text = settings.McmcSteps.ToString();
             mcmcRandomSeedTextBox.Text = settings.RandomSeed.ToString();
             requireMsmsIdInConditionCheckbox.IsChecked = settings.RequireMsmsIdInCondition;
@@ -132,7 +132,7 @@ namespace GUI
             // MBR FDR
             if (double.TryParse(mbrFDRTextBox.Text, NumberStyles.Number, CultureInfo.InvariantCulture, out double mbrFdr))
             {
-                settings.MbrDetectionQValueThreshold = mbrFdr;
+                settings.MbrQValueThreshold = mbrFdr;
             }
             else
             {
@@ -193,7 +193,7 @@ namespace GUI
             // MBR time tolerance
             if (double.TryParse(mbrRtWindowTextBox.Text, NumberStyles.Number, CultureInfo.InvariantCulture, out double MbrRtWindow))
             {
-                settings.MbrRtWindow = MbrRtWindow;
+                settings.MaxMbrRtWindow = MbrRtWindow;
             }
             else
             {
@@ -622,7 +622,7 @@ namespace GUI
             {
                 try
                 {
-                    OutputWriter.WriteOutput(Directory.GetParent(spectraFiles.First().FilePath).FullName, results, flashLfqEngine.Silent,
+                    OutputWriter.WriteOutput(Directory.GetParent(spectraFiles.First().FilePath).FullName, results, flashLfqEngine.FlashParams.Silent,
                         outputFolderPath);
 
                     MessageBox.Show("Run complete");

--- a/Test/Test.cs
+++ b/Test/Test.cs
@@ -539,7 +539,7 @@ namespace Test
 
             FlashLfqEngine e = FlashLfqSettings.CreateEngineWithSettings(settings, new List<Identification>());
 
-            var engineProperties = e.GetType().GetFields();
+            var engineProperties = e.FlashParams.GetType().GetProperties();
 
             // check to make sure the settings got passed properly into the engine (the settings should have identical values)
             foreach (var property in properties)
@@ -563,7 +563,7 @@ namespace Test
                 var engineProperty = engineProperties.FirstOrDefault(p => p.Name == name);
 
                 var settingsValue = property.GetValue(settings);
-                var engineValue = engineProperty.GetValue(e);
+                var engineValue = engineProperty.GetValue(e.FlashParams);
 
                 Assert.That(settingsValue, Is.EqualTo(engineValue));
             }

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.553" />
+    <PackageReference Include="mzLib" Version="8.1.2" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="nunit" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />

--- a/Util/Util.csproj
+++ b/Util/Util.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.553" />
+    <PackageReference Include="mzLib" Version="8.1.2" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>


### PR DESCRIPTION
The current master of mzLib has FlashLFQ refactored such that parameters are stored in a new FlashLfqParameters class. 

This PR enables FlashLFQ to work with the latest version of mzLib without breaking.

However, the integrations of the FlashLfqSettings in FlashLFQ and the FlashLfqParameters class in mzLib/FlashLFQ is clumsy. It's working, but the future directoin is to integrate this more seamlessly. FlashLFQ should be able to write/read FlashLfqParameters to/from .toml files, instead of having a custom .toml for FlashLfqSettings